### PR TITLE
Discard master and slave language

### DIFF
--- a/core/handlers/boterator/reg.py
+++ b/core/handlers/boterator/reg.py
@@ -22,16 +22,16 @@ def reg_command(bot, message):
     yield bot.send_message(pgettext('/reg response', 'Ok, please tell me the token, which you\'ve received from '
                                                      '@BotFather'),
                            reply_to_message=message)
-    slave_settings = deepcopy(DEFAULT_SLAVE_SETTINGS)
-    slave_settings['locale'] = bot.get_settings(message['from']['id']).get('locale', 'en_US')
-    locale = tornado.locale.get(slave_settings['locale'])
-    slave_settings['hello'].locale = locale
-    slave_settings['hello'] = str(slave_settings['hello'])
-    slave_settings['start'].locale = locale
-    slave_settings['start'] = str(slave_settings['start'])
+    subordinate_settings = deepcopy(DEFAULT_SLAVE_SETTINGS)
+    subordinate_settings['locale'] = bot.get_settings(message['from']['id']).get('locale', 'en_US')
+    locale = tornado.locale.get(subordinate_settings['locale'])
+    subordinate_settings['hello'].locale = locale
+    subordinate_settings['hello'] = str(subordinate_settings['hello'])
+    subordinate_settings['start'].locale = locale
+    subordinate_settings['start'] = str(subordinate_settings['start'])
 
     return {
-        'settings': slave_settings,
+        'settings': subordinate_settings,
         'owner_id': message['from']['id'],
     }
 
@@ -111,7 +111,7 @@ def plaintext_token(bot, message, **kwargs):
         elif not chat['title']:
             chat['title'] = '<no title>'
 
-        msg = pgettext('Slave attached to moderator`s channel',
+        msg = pgettext('Subordinate attached to moderator`s channel',
                        "Ok, I'll be sending moderation requests to {chat_type} {chat_title}\n"
                        "Now you need to add your bot (@{bot_username_escaped}) to a channel as administrator and tell "
                        "me the channel name (e.g. @mobilenewsru)\n"
@@ -129,7 +129,7 @@ def plaintext_token(bot, message, **kwargs):
         except:
             yield bot.send_message(msg, reply_to_message=message)
 
-        report_botan(message, 'boterator_slave_attached_to_channel')
+        report_botan(message, 'boterator_subordinate_attached_to_channel')
 
         return {
             'id': new_bot_info['id'],

--- a/core/handlers/slave/ban.py
+++ b/core/handlers/slave/ban.py
@@ -2,7 +2,7 @@ from tornado.gen import coroutine
 
 from tobot import CommandFilterTextRegexp, CommandFilterTextCmd, CommandFilterTextAny, \
     CommandFilterCallbackQueryRegexp
-from core.slave_command_filters import CommandFilterIsModerationChat
+from core.subordinate_command_filters import CommandFilterIsModerationChat
 from tobot.helpers import report_botan, pgettext
 from tobot.telegram import ForceReply
 
@@ -11,7 +11,7 @@ from tobot.telegram import ForceReply
 @CommandFilterIsModerationChat()
 @CommandFilterCallbackQueryRegexp(r'ban_(?P<user_id>\d+)(?:_(?P<chat_id>\d+)_(?P<message_id>\d+))?')
 def ban_command(bot, callback_query, user_id, chat_id=None, message_id=None):
-    report_botan(callback_query, 'slave_ban_cmd')
+    report_botan(callback_query, 'subordinate_ban_cmd')
 
     if int(user_id) == callback_query['from']['id']:
         yield bot.answer_callback_query(callback_query['id'],
@@ -61,12 +61,12 @@ def plaintext_ban_handler(bot, message, user_id):
 
     msg = message['text'].strip()
     if len(msg) < 5:
-        report_botan(message, 'slave_ban_short_msg')
+        report_botan(message, 'subordinate_ban_short_msg')
         yield bot.send_message(pgettext('Ban reason too short', 'Reason is too short (5 symbols required), '
                                                                 'try again or send /cancel'),
                                reply_to_message=message, reply_markup=ForceReply(True))
     else:
-        report_botan(message, 'slave_ban_success')
+        report_botan(message, 'subordinate_ban_success')
         yield bot.send_chat_action(chat_id, bot.CHAT_ACTION_TYPING)
         try:
             yield bot.send_message(pgettext('Message to user in case of ban',
@@ -95,7 +95,7 @@ def plaintext_ban_handler(bot, message, user_id):
 @CommandFilterIsModerationChat()
 @CommandFilterTextRegexp(r'/unban_(?P<user_id>\d+)')
 def unban_command(bot, message, user_id):
-    report_botan(message, 'slave_unban_cmd')
+    report_botan(message, 'subordinate_unban_cmd')
     yield bot.db.execute('UPDATE users SET banned_at = NULL, ban_reason = NULL WHERE user_id = %s AND '
                          'bot_id = %s', (user_id, bot.id))
     yield bot.send_message(pgettext('Unban confirmation', 'User unbanned'), reply_to_message=message)
@@ -111,7 +111,7 @@ def unban_command(bot, message, user_id):
 @CommandFilterTextCmd('/banlist')
 def ban_list_command(bot, message):
     chat_id = message['chat']['id']
-    report_botan(message, 'slave_ban_list_cmd')
+    report_botan(message, 'subordinate_ban_list_cmd')
     yield bot.send_chat_action(chat_id, bot.CHAT_ACTION_TYPING)
     cur = yield bot.db.execute('SELECT user_id, first_name, last_name, username, banned_at, ban_reason '
                                'FROM users WHERE bot_id = %s AND '

--- a/core/handlers/slave/chat.py
+++ b/core/handlers/slave/chat.py
@@ -8,7 +8,7 @@ from tobot.helpers import report_botan
 @CommandFilterNewChatMemberAny()
 def new_chat(bot, message):
     if message['new_chat_member']['id'] == bot.bot_id and message['chat']['id'] == bot.moderator_chat_id:
-        report_botan(message, 'slave_renew_chat')
+        report_botan(message, 'subordinate_renew_chat')
         yield bot.db.execute('UPDATE registered_bots SET active = TRUE WHERE id = %s', (bot.bot_id,))
     else:
         return False
@@ -18,7 +18,7 @@ def new_chat(bot, message):
 @CommandFilterLeftChatMemberAny()
 def left_chat(bot, message):
     if message['left_chat_member']['id'] == bot.bot_id and message['chat']['id'] == bot.moderator_chat_id:
-        report_botan(message, 'slave_left_chat')
+        report_botan(message, 'subordinate_left_chat')
         yield bot.db.execute('UPDATE registered_bots SET active = FALSE WHERE id = %s', (bot.bot_id,))
     else:
         return False

--- a/core/handlers/slave/help.py
+++ b/core/handlers/slave/help.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext, npgettext, Emoji
 
 
@@ -9,7 +9,7 @@ from tobot.helpers import report_botan, pgettext, npgettext, Emoji
 @CommandFilterIsPowerfulUser()
 @CommandFilterTextCmd('/help')
 def help_command(bot, message):
-    report_botan(message, 'slave_help')
+    report_botan(message, 'subordinate_help')
     delay_str = npgettext('Delay between channel messages', '{delay} minute', '{delay} minutes', bot.settings['delay'])
     timeout_str = npgettext('Voting timeout', '{timeout} hour', '{timeout} hours', bot.settings['vote_timeout'])
     power_state = 'on' if bot.settings.get('power') else 'off'

--- a/core/handlers/slave/pollslist.py
+++ b/core/handlers/slave/pollslist.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsModerationChat
+from core.subordinate_command_filters import CommandFilterIsModerationChat
 from tobot.helpers import pgettext, npgettext
 
 

--- a/core/handlers/slave/post.py
+++ b/core/handlers/slave/post.py
@@ -39,12 +39,12 @@ def plaintext_post_handler(bot, message):
     if mes.strip() != '':
         if bot.settings['text_min'] <= len(mes) <= bot.settings['text_max']:
             yield _request_message_confirmation(bot, message)
-            report_botan(message, 'slave_message')
+            report_botan(message, 'subordinate_message')
             return {
                 'sent_message': message
             }
         else:
-            report_botan(message, 'slave_message_invalid')
+            report_botan(message, 'subordinate_message_invalid')
             yield bot.send_message(pgettext('Incorrect text message received', 'Sorry, but we can proceed only '
                                                                                'messages with length between '
                                                                                '{min_msg_length} and {max_msg_length} '
@@ -53,7 +53,7 @@ def plaintext_post_handler(bot, message):
                                            max_msg_length=format_number(bot.settings['text_max'], bot.language)),
                                    reply_to_message=message)
     else:
-        report_botan(message, 'slave_message_empty')
+        report_botan(message, 'subordinate_message_empty')
         yield bot.send_message(pgettext('User sent empty message', 'Seriously??? 8===3'),
                                reply_to_message=message)
 
@@ -93,7 +93,7 @@ def multimedia_post_handler(bot, message):
                                         'Accepting gifs is disabled'), reply_to_message=message)
         return
 
-    report_botan(message, 'slave_message_multimedia')
+    report_botan(message, 'subordinate_message_multimedia')
     yield _request_message_confirmation(bot, message)
     return {
         'sent_message': message
@@ -105,7 +105,7 @@ def multimedia_post_handler(bot, message):
 def cbq_message_review(bot, callback_query, sent_message):
     user_id = callback_query['from']['id']
 
-    report_botan(callback_query, 'slave_confirm')
+    report_botan(callback_query, 'subordinate_confirm')
     yield bot.db.execute("""
     INSERT INTO incoming_messages (id, original_chat_id, owner_id, bot_id, created_at, message)
     VALUES (%s, %s, %s, %s, NOW(), %s)

--- a/core/handlers/slave/reject.py
+++ b/core/handlers/slave/reject.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextAny, CommandFilterCallbackQueryRegexp
-from core.slave_command_filters import CommandFilterIsModerationChat
+from core.subordinate_command_filters import CommandFilterIsModerationChat
 from tobot.helpers import pgettext, report_botan
 from tobot.telegram import ForceReply
 
@@ -10,7 +10,7 @@ from tobot.telegram import ForceReply
 @CommandFilterIsModerationChat()
 @CommandFilterCallbackQueryRegexp(r'reject_(?P<chat_id>\d+)_(?P<message_id>\d+)')
 def reject_command(bot, callback_query, chat_id, message_id):
-    report_botan(callback_query, 'slave_reject_cmd')
+    report_botan(callback_query, 'subordinate_reject_cmd')
     msg = pgettext('Reject message request', 'Please enter a reject reason, @{moderator_username}?') \
         .format(moderator_username=callback_query['from'].get('username', callback_query['from']['id']))
     fwd_id = yield bot.get_message_fwd_id(chat_id, message_id)
@@ -28,7 +28,7 @@ def reject_command(bot, callback_query, chat_id, message_id):
 def plaintext_reject_handler(bot, message, chat_id, message_id):
     msg = message['text'].strip()
     if len(msg) < 10:
-        report_botan(message, 'slave_reply_short_msg')
+        report_botan(message, 'subordinate_reply_short_msg')
         yield bot.send_message(
             pgettext('Reject message is too short', 'Reject message is too short (10 symbols required), try '
                                                     'again or send /cancel'),

--- a/core/handlers/slave/reply.py
+++ b/core/handlers/slave/reply.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextAny, CommandFilterCallbackQueryRegexp
-from core.slave_command_filters import CommandFilterIsModerationChat
+from core.subordinate_command_filters import CommandFilterIsModerationChat
 from tobot.helpers import pgettext, report_botan
 from tobot.telegram import ForceReply
 
@@ -10,7 +10,7 @@ from tobot.telegram import ForceReply
 @CommandFilterIsModerationChat()
 @CommandFilterCallbackQueryRegexp(r'reply_(?P<chat_id>\d+)_(?P<message_id>\d+)')
 def reply_command(bot, callback_query, chat_id, message_id):
-    report_botan(callback_query, 'slave_reply_cmd')
+    report_botan(callback_query, 'subordinate_reply_cmd')
     msg = pgettext('Reply message request', 'What message should I send to user, @{moderator_username}?') \
         .format(moderator_username=callback_query['from'].get('username', callback_query['from']['id']))
     fwd_id = yield bot.get_message_fwd_id(chat_id, message_id)
@@ -28,7 +28,7 @@ def reply_command(bot, callback_query, chat_id, message_id):
 def plaintext_reply_handler(bot, message, chat_id, message_id):
     msg = message['text'].strip()
     if len(msg) < 10:
-        report_botan(message, 'slave_reply_short_msg')
+        report_botan(message, 'subordinate_reply_short_msg')
         yield bot.send_message(pgettext('Reply message is too short', 'Message is too short (10 symbols required), try '
                                                                       'again or send /cancel'),
                                reply_to_message=message, reply_markup=ForceReply(True))

--- a/core/handlers/slave/setallowed.py
+++ b/core/handlers/slave/setallowed.py
@@ -4,7 +4,7 @@ from math import floor
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import Emoji, pgettext, report_botan
 from tobot.telegram import ReplyKeyboardMarkup, KeyboardButton
 
@@ -45,7 +45,7 @@ def build_contenttype_keyboard(bot):
 @CommandFilterTextCmd('/setallowed')
 @CommandFilterIsPowerfulUser()
 def change_allowed_command(bot, message):
-    report_botan(message, 'slave_change_allowed_cmd')
+    report_botan(message, 'subordinate_change_allowed_cmd')
     yield bot.send_message(pgettext('/changeallowed response', 'You can see current status on keyboard, just click on '
                                                                'content type to change it\'s status'),
                            reply_to_message=message, reply_markup=build_contenttype_keyboard(bot))
@@ -81,7 +81,7 @@ def plaintext_contenttype_handler(bot, message):
 
         action_text = 'enable' if action_type else 'disable'
 
-        report_botan(message, 'slave_content_' + content_type_raw + '_' + action_text)
+        report_botan(message, 'subordinate_content_' + content_type_raw + '_' + action_text)
 
         msg = content_type_raw[0].upper() + content_type_raw[1:] + 's ' + action_text + 'd'
 

--- a/core/handlers/slave/setdelay.py
+++ b/core/handlers/slave/setdelay.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext
 from tobot.telegram import ForceReply
 
@@ -10,7 +10,7 @@ from tobot.telegram import ForceReply
 @CommandFilterIsPowerfulUser()
 @CommandFilterTextCmd('/setdelay')
 def setdelay_command(bot, message):
-    report_botan(message, 'slave_setdelay_cmd')
+    report_botan(message, 'subordinate_setdelay_cmd')
     yield bot.send_message(pgettext('New delay request', 'Set new delay value for messages posting (in minutes)'),
                            reply_to_message=message, reply_markup=ForceReply(True))
     return True
@@ -19,12 +19,12 @@ def setdelay_command(bot, message):
 @coroutine
 def plaintext_delay_handler(bot, message):
     if message['text'].isdigit() and int(message['text']) >= 0:
-        report_botan(message, 'slave_setdelay')
+        report_botan(message, 'subordinate_setdelay')
         yield bot.update_settings(message['from']['id'], delay=int(message['text']))
         yield bot.send_message(pgettext('Messages delay successfully changed', 'Delay value updated'),
                                reply_to_message=message)
         return True
     else:
-        report_botan(message, 'slave_setdelay_invalid')
+        report_botan(message, 'subordinate_setdelay_invalid')
         yield bot.send_message(pgettext('Invalid delay value', 'Invalid delay value. Try again or type /cancel'),
                                reply_to_message=message, reply_markup=ForceReply(True))

--- a/core/handlers/slave/setfreqlimit.py
+++ b/core/handlers/slave/setfreqlimit.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import pgettext
 from tobot.telegram import ForceReply
 

--- a/core/handlers/slave/setlanguage.py
+++ b/core/handlers/slave/setlanguage.py
@@ -6,7 +6,7 @@ from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd, CommandFilterTextAny
 from core.settings import LANGUAGE_LIST
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import Emoji, pgettext
 from tobot.telegram import KeyboardButton, ReplyKeyboardMarkup, ReplyKeyboardHide
 

--- a/core/handlers/slave/setstartmessage.py
+++ b/core/handlers/slave/setstartmessage.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext
 from tobot.telegram import ForceReply
 
@@ -10,7 +10,7 @@ from tobot.telegram import ForceReply
 @CommandFilterTextCmd('/setstartmessage')
 @CommandFilterIsPowerfulUser()
 def setstartmessage_command(bot, message):
-    report_botan(message, 'slave_setstartmessage_cmd')
+    report_botan(message, 'subordinate_setstartmessage_cmd')
     yield bot.send_message(pgettext('New start message request', 'Set new start message'), reply_to_message=message,
                            reply_markup=ForceReply(True))
     return True
@@ -19,13 +19,13 @@ def setstartmessage_command(bot, message):
 @coroutine
 def plaintext_startmessage_handler(bot, message):
     if message['text'] and len(message['text'].strip()) > 10:
-        report_botan(message, 'slave_setstartmessage')
+        report_botan(message, 'subordinate_setstartmessage')
         yield bot.update_settings(message['from']['id'], start=message['text'].strip())
         yield bot.send_message(pgettext('Start message successfully changed', 'Start message updated'),
                                reply_to_message=message)
         return True
     else:
-        report_botan(message, 'slave_setstartmessage_invalid')
+        report_botan(message, 'subordinate_setstartmessage_invalid')
         yield bot.send_message(pgettext('Too short start message entered', 'Invalid start message, you should write at '
                                                                            'least 10 symbols. Try again or type '
                                                                            '/cancel'),

--- a/core/handlers/slave/settextlimits.py
+++ b/core/handlers/slave/settextlimits.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import pgettext
 from tobot.telegram import ForceReply
 

--- a/core/handlers/slave/settimeout.py
+++ b/core/handlers/slave/settimeout.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import pgettext, report_botan
 from tobot.telegram import ForceReply
 
@@ -10,7 +10,7 @@ from tobot.telegram import ForceReply
 @CommandFilterTextCmd('/settimeout')
 @CommandFilterIsPowerfulUser()
 def settimeout_command(bot, message):
-    report_botan(message, 'slave_settimeout_cmd')
+    report_botan(message, 'subordinate_settimeout_cmd')
     yield bot.send_message(pgettext('New voting duration request', 'Set new voting duration value (in hours, only a '
                                                                    'digits)'),
                            reply_to_message=message, reply_markup=ForceReply(True))
@@ -20,13 +20,13 @@ def settimeout_command(bot, message):
 @coroutine
 def plaintext_timeout_handler(bot, message):
     if message['text'].isdigit() and int(message['text']) > 0:
-        report_botan(message, 'slave_settimeout')
+        report_botan(message, 'subordinate_settimeout')
         yield bot.update_settings(message['from']['id'], vote_timeout=int(message['text']))
         yield bot.send_message(pgettext('Voting duration successfully changed', 'Voting duration updated'),
                                reply_to_message=message)
         return True
     else:
-        report_botan(message, 'slave_settimeout_invalid')
+        report_botan(message, 'subordinate_settimeout_invalid')
         yield bot.send_message(pgettext('Invalid voting duration value', 'Invalid voting duration value. Try again or '
                                                                          'type /cancel'),
                                reply_to_message=message, reply_markup=ForceReply(True))

--- a/core/handlers/slave/setvotes.py
+++ b/core/handlers/slave/setvotes.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import pgettext, report_botan
 from tobot.telegram import ForceReply
 
@@ -10,7 +10,7 @@ from tobot.telegram import ForceReply
 @CommandFilterTextCmd('/setvotes')
 @CommandFilterIsPowerfulUser()
 def setvotes_command(bot, message):
-    report_botan(message, 'slave_setvotes_cmd')
+    report_botan(message, 'subordinate_setvotes_cmd')
     yield bot.send_message(
         pgettext('New required votes count request', 'Set new amount of required votes'),
         reply_to_message=message, reply_markup=ForceReply(True))
@@ -20,14 +20,14 @@ def setvotes_command(bot, message):
 @coroutine
 def plaintext_votes_handler(bot, message):
     if message['text'].isdigit() and int(message['text']) > 0:
-        report_botan(message, 'slave_setvotes')
+        report_botan(message, 'subordinate_setvotes')
         yield bot.update_settings(message['from']['id'], votes=int(message['text']))
         yield bot.send_message(pgettext('Required votes count successfully changed', 'Required votes '
                                                                                      'amount updated'),
                                reply_to_message=message)
         return True
     else:
-        report_botan(message, 'slave_setvotes_invalid')
+        report_botan(message, 'subordinate_setvotes_invalid')
         yield bot.send_message(pgettext('Invalid votes amount value', 'Invalid votes amount value. Try again or type '
                                                                       '/cancel'),
                                reply_to_message=message, reply_markup=ForceReply(True))

--- a/core/handlers/slave/start.py
+++ b/core/handlers/slave/start.py
@@ -7,7 +7,7 @@ from tobot.helpers import report_botan
 @coroutine
 @CommandFilterTextCmd('/start')
 def start_command(bot, message):
-    report_botan(message, 'slave_start')
+    report_botan(message, 'subordinate_start')
     username = message['from'].get('username', message['from']['first_name'])
     if message['from'].get('first_name', '').strip():
         username = message['from']['first_name'].strip()

--- a/core/handlers/slave/stats.py
+++ b/core/handlers/slave/stats.py
@@ -5,7 +5,7 @@ from babel.numbers import format_number
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsModerator
+from core.subordinate_command_filters import CommandFilterIsModerator
 from tobot.helpers import pgettext, Emoji, npgettext, report_botan
 from tobot.helpers.lazy_gettext import set_locale_recursive
 
@@ -34,7 +34,7 @@ def stats_command(bot, message):
 
         return ret
 
-    report_botan(message, 'slave_stats')
+    report_botan(message, 'subordinate_stats')
 
     period = message['text'][6:].strip()
     if period:

--- a/core/handlers/slave/toggle_power.py
+++ b/core/handlers/slave/toggle_power.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext
 
 
@@ -9,7 +9,7 @@ from tobot.helpers import report_botan, pgettext
 @CommandFilterTextCmd('/togglepower')
 @CommandFilterIsPowerfulUser()
 def togglepower_command(bot, message):
-    report_botan(message, 'slave_togglepower_cmd')
+    report_botan(message, 'subordinate_togglepower_cmd')
     if bot.settings.get('power'):
         yield bot.update_settings(message['from']['id'], power=False)
         yield bot.send_message(pgettext('Power mode disabled', 'From now other chat users can not modify bot settings'),

--- a/core/handlers/slave/toggle_selfvote.py
+++ b/core/handlers/slave/toggle_selfvote.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext
 
 
@@ -9,7 +9,7 @@ from tobot.helpers import report_botan, pgettext
 @CommandFilterTextCmd('/toggleselfvote')
 @CommandFilterIsPowerfulUser()
 def toggleselfvote_command(bot, message):
-    report_botan(message, 'slave_toggleselfvote_cmd')
+    report_botan(message, 'subordinate_toggleselfvote_cmd')
     if bot.settings.get('selfvote'):
         yield bot.update_settings(message['from']['id'], selfvote=False)
         yield bot.send_message(pgettext('Self-vote disabled', 'From now moderators WILL NOT be able to vote for own '

--- a/core/handlers/slave/toggle_start_web_preview.py
+++ b/core/handlers/slave/toggle_start_web_preview.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext
 
 
@@ -9,7 +9,7 @@ from tobot.helpers import report_botan, pgettext
 @CommandFilterTextCmd('/togglestartwebpreview')
 @CommandFilterIsPowerfulUser()
 def toggle_start_web_preview_command(bot, message):
-    report_botan(message, 'slave_toggle_start_web_preview_cmd')
+    report_botan(message, 'subordinate_toggle_start_web_preview_cmd')
     if bot.settings.get('start_web_preview'):
         yield bot.update_settings(message['from']['id'], start_web_preview=False)
         yield bot.send_message(pgettext('Web preview disabled in /start', 'From now web previews WILL NOT BE generated '

--- a/core/handlers/slave/toggle_tag_polls.py
+++ b/core/handlers/slave/toggle_tag_polls.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext
 
 
@@ -9,7 +9,7 @@ from tobot.helpers import report_botan, pgettext
 @CommandFilterTextCmd('/toggletagpolls')
 @CommandFilterIsPowerfulUser()
 def toggletagpolls_command(bot, message):
-    report_botan(message, 'slave_toggletagpolls_cmd')
+    report_botan(message, 'subordinate_toggletagpolls_cmd')
     if bot.settings.get('tag_polls'):
         yield bot.update_settings(message['from']['id'], tag_polls=False)
         yield bot.send_message(pgettext('Polls tagging disabled', 'State tags shall not pass.'),

--- a/core/handlers/slave/toggle_vote.py
+++ b/core/handlers/slave/toggle_vote.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext
 
 
@@ -9,7 +9,7 @@ from tobot.helpers import report_botan, pgettext
 @CommandFilterTextCmd('/togglevote')
 @CommandFilterIsPowerfulUser()
 def togglevote_command(bot, message):
-    report_botan(message, 'slave_togglevote_cmd')
+    report_botan(message, 'subordinate_togglevote_cmd')
     if bot.settings.get('public_vote'):
         yield bot.update_settings(message['from']['id'], public_vote=False)
         yield bot.send_message(pgettext('Vote status displaying disabled', 'From now other chat users WILL NOT see '

--- a/core/handlers/slave/toggle_vote_switch.py
+++ b/core/handlers/slave/toggle_vote_switch.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterTextCmd
-from core.slave_command_filters import CommandFilterIsPowerfulUser
+from core.subordinate_command_filters import CommandFilterIsPowerfulUser
 from tobot.helpers import report_botan, pgettext
 
 
@@ -9,7 +9,7 @@ from tobot.helpers import report_botan, pgettext
 @CommandFilterTextCmd('/togglevoteswitch')
 @CommandFilterIsPowerfulUser()
 def togglevoteswitch_command(bot, message):
-    report_botan(message, 'slave_togglevoteswitch_cmd')
+    report_botan(message, 'subordinate_togglevoteswitch_cmd')
     if bot.settings.get('allow_vote_switch'):
         yield bot.update_settings(message['from']['id'], allow_vote_switch=False)
         yield bot.send_message(pgettext('Vote switching disabled', 'From now Moderators can NOT switch their votes'),

--- a/core/handlers/slave/vote.py
+++ b/core/handlers/slave/vote.py
@@ -1,7 +1,7 @@
 from tornado.gen import coroutine
 
 from tobot import CommandFilterCallbackQueryRegexp, CommandFilterTextRegexp
-from core.slave_command_filters import CommandFilterIsModerationChat
+from core.subordinate_command_filters import CommandFilterIsModerationChat
 from tobot.helpers import pgettext, report_botan
 
 
@@ -98,7 +98,7 @@ def __vote(bot, message_id, original_chat_id, yes: bool, callback_query=None, me
                                            chat_id=original_chat_id, reply_to_message_id=message_id)
                 except:
                     pass
-                report_botan(row[1], 'slave_verification_success')
+                report_botan(row[1], 'subordinate_verification_success')
         elif current_total - current_yes >= bot.settings.get('votes', 5):
             cur = yield bot.db.execute('SELECT is_voting_fail, is_voting_success, message FROM incoming_messages '
                                        'WHERE id = %s AND original_chat_id = %s', (message_id, original_chat_id))
@@ -126,7 +126,7 @@ def __vote(bot, message_id, original_chat_id, yes: bool, callback_query=None, me
 @CommandFilterIsModerationChat()
 @CommandFilterCallbackQueryRegexp(r'vote_(?P<original_chat_id>\d+)_(?P<message_id>\d+)_(?P<vote_type>yes|no)')
 def vote_new(bot, callback_query, original_chat_id, message_id, vote_type):
-    report_botan(callback_query, 'slave_vote_yes')
+    report_botan(callback_query, 'subordinate_vote_yes')
     yield __vote(bot, message_id, original_chat_id, vote_type == 'yes', callback_query=callback_query)
 
 
@@ -134,5 +134,5 @@ def vote_new(bot, callback_query, original_chat_id, message_id, vote_type):
 @CommandFilterIsModerationChat()
 @CommandFilterTextRegexp(r'/vote_(?P<original_chat_id>\d+)_(?P<message_id>\d+)_(?P<vote_type>yes|no)')
 def vote_old(bot, message, original_chat_id, message_id, vote_type):
-    report_botan(message, 'slave_vote_yes')
+    report_botan(message, 'subordinate_vote_yes')
     yield __vote(bot, message_id, original_chat_id, vote_type == 'yes', message=message)

--- a/core/queues.py
+++ b/core/queues.py
@@ -4,10 +4,10 @@ from tornado.gen import coroutine, with_timeout
 from ujson import dumps, loads
 
 QUEUE_BOTERATOR_BOT_REVOKE = 'boterator_bot_revoke'
-QUEUE_SLAVEHOLDER_NEW_BOT = 'slaveholder_new_bot'
-QUEUE_SLAVEHOLDER_GET_BOT_INFO = 'slaveholder_get_bot_info'
-QUEUE_SLAVEHOLDER_GET_MODERATION_GROUP = 'slaveholder_get_moderation_group'
-QUEUE_SLAVEHOLDER_STOP_BOT = 'slaveholder_stop_bot'
+QUEUE_SLAVEHOLDER_NEW_BOT = 'subordinateholder_new_bot'
+QUEUE_SLAVEHOLDER_GET_BOT_INFO = 'subordinateholder_get_bot_info'
+QUEUE_SLAVEHOLDER_GET_MODERATION_GROUP = 'subordinateholder_get_moderation_group'
+QUEUE_SLAVEHOLDER_STOP_BOT = 'subordinateholder_stop_bot'
 
 
 def boterator_queues():
@@ -15,7 +15,7 @@ def boterator_queues():
             if queue_variable.startswith('QUEUE_BOTERATOR_')]
 
 
-def slaveholder_queues():
+def subordinateholder_queues():
     return [queue_name for queue_variable, queue_name in globals().items()
             if queue_variable.startswith('QUEUE_SLAVEHOLDER_')]
 

--- a/core/slave.py
+++ b/core/slave.py
@@ -10,36 +10,36 @@ from tobot import Base
 from tobot.stages import PersistentStages
 from core.handlers.cancel import cancel_command
 from core.handlers.emoji_end import emoji_end
-from core.handlers.slave.ban import ban_command, plaintext_ban_handler, unban_command, ban_list_command
-from core.handlers.slave.check_freq import check_freq
-from core.handlers.slave.help import help_command
-from core.handlers.slave.migrate_to_supergroup import migrate, migrate_to_supergroup_msg
-from core.handlers.slave.pollslist import polls_list_command
-from core.handlers.slave.reject import reject_command, plaintext_reject_handler
-from core.handlers.slave.reply import reply_command, plaintext_reply_handler
-from core.handlers.slave.setallowed import change_allowed_command, plaintext_contenttype_handler
-from core.handlers.slave.setdelay import setdelay_command, plaintext_delay_handler
-from core.handlers.slave.setfreqlimit import setfreqlimit_command, plaintext_freqlimit_handler
-from core.handlers.slave.setlanguage import setlanguage, setlanguage_plaintext
-from core.handlers.slave.chat import new_chat, left_chat
-from core.handlers.slave.post import plaintext_post_handler, multimedia_post_handler, cbq_message_review, \
+from core.handlers.subordinate.ban import ban_command, plaintext_ban_handler, unban_command, ban_list_command
+from core.handlers.subordinate.check_freq import check_freq
+from core.handlers.subordinate.help import help_command
+from core.handlers.subordinate.migrate_to_supergroup import migrate, migrate_to_supergroup_msg
+from core.handlers.subordinate.pollslist import polls_list_command
+from core.handlers.subordinate.reject import reject_command, plaintext_reject_handler
+from core.handlers.subordinate.reply import reply_command, plaintext_reply_handler
+from core.handlers.subordinate.setallowed import change_allowed_command, plaintext_contenttype_handler
+from core.handlers.subordinate.setdelay import setdelay_command, plaintext_delay_handler
+from core.handlers.subordinate.setfreqlimit import setfreqlimit_command, plaintext_freqlimit_handler
+from core.handlers.subordinate.setlanguage import setlanguage, setlanguage_plaintext
+from core.handlers.subordinate.chat import new_chat, left_chat
+from core.handlers.subordinate.post import plaintext_post_handler, multimedia_post_handler, cbq_message_review, \
     cbq_cancel_publishing
-from core.handlers.slave.setstartmessage import plaintext_startmessage_handler
-from core.handlers.slave.setstartmessage import setstartmessage_command
-from core.handlers.slave.settextlimits import plaintext_textlimits_handler, settextlimits_command
-from core.handlers.slave.settimeout import plaintext_timeout_handler
-from core.handlers.slave.settimeout import settimeout_command
-from core.handlers.slave.setvotes import plaintext_votes_handler
-from core.handlers.slave.setvotes import setvotes_command
-from core.handlers.slave.start import start_command
-from core.handlers.slave.stats import stats_command
-from core.handlers.slave.toggle_power import togglepower_command
-from core.handlers.slave.toggle_selfvote import toggleselfvote_command
-from core.handlers.slave.toggle_start_web_preview import toggle_start_web_preview_command
-from core.handlers.slave.toggle_tag_polls import toggletagpolls_command
-from core.handlers.slave.toggle_vote import togglevote_command
-from core.handlers.slave.toggle_vote_switch import togglevoteswitch_command
-from core.handlers.slave.vote import vote_new, vote_old
+from core.handlers.subordinate.setstartmessage import plaintext_startmessage_handler
+from core.handlers.subordinate.setstartmessage import setstartmessage_command
+from core.handlers.subordinate.settextlimits import plaintext_textlimits_handler, settextlimits_command
+from core.handlers.subordinate.settimeout import plaintext_timeout_handler
+from core.handlers.subordinate.settimeout import settimeout_command
+from core.handlers.subordinate.setvotes import plaintext_votes_handler
+from core.handlers.subordinate.setvotes import setvotes_command
+from core.handlers.subordinate.start import start_command
+from core.handlers.subordinate.stats import stats_command
+from core.handlers.subordinate.toggle_power import togglepower_command
+from core.handlers.subordinate.toggle_selfvote import toggleselfvote_command
+from core.handlers.subordinate.toggle_start_web_preview import toggle_start_web_preview_command
+from core.handlers.subordinate.toggle_tag_polls import toggletagpolls_command
+from core.handlers.subordinate.toggle_vote import togglevote_command
+from core.handlers.subordinate.toggle_vote_switch import togglevoteswitch_command
+from core.handlers.subordinate.vote import vote_new, vote_old
 from core.handlers.unknown_command import unknown_command
 from core.handlers.validate_user import validate_user
 from core.settings import DEFAULT_SLAVE_SETTINGS
@@ -48,7 +48,7 @@ from tobot.helpers.lazy_gettext import set_locale_recursive
 from tobot.telegram import InlineKeyboardMarkup, InlineKeyboardButton, ApiError
 
 
-class Slave(Base):
+class Subordinate(Base):
     def __init__(self, token, db, **kwargs):
         bot_settings = kwargs.pop('settings', {})
         if 'hello' in bot_settings:
@@ -188,7 +188,7 @@ class Slave(Base):
 
     @coroutine
     def publish_message(self, message, moderation_message_id):
-        report_botan(message, 'slave_publish')
+        report_botan(message, 'subordinate_publish')
         try:
             conn = yield self.db.getconn()
             with self.db.manage(conn):
@@ -229,7 +229,7 @@ class Slave(Base):
         for message, yes_votes in cur.fetchall():
             if yes_votes is None:
                 yes_votes = 0
-            report_botan(message, 'slave_verification_failed')
+            report_botan(message, 'subordinate_verification_failed')
             try:
                 yield self.decline_message(message, yes_votes)
             except:

--- a/slaveholder_server.py
+++ b/slaveholder_server.py
@@ -9,7 +9,7 @@ from tornado.ioloop import IOLoop
 from tornado.options import define, options, parse_command_line
 from os import environ
 
-from core.slave_holder import SlaveHolder
+from core.subordinate_holder import SubordinateHolder
 
 
 if __name__ == '__main__':
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     if options.debug:
         autoreload.start()
 
-    sh = SlaveHolder(db, Burlesque(options.burlesque))
+    sh = SubordinateHolder(db, Burlesque(options.burlesque))
     try:
         ioloop.run_sync(sh.start)
     except Exception as e:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.